### PR TITLE
Fix StartProcessing references

### DIFF
--- a/VB-Structure-dev/Modules/modMain.bas
+++ b/VB-Structure-dev/Modules/modMain.bas
@@ -11,16 +11,17 @@ Public Sub StartProcessing()
     Dim i As Long
 
     For i = 1 To 5
-        findTexts(i) = Me.Controls("txtFind" & i).text
-        replaceTexts(i) = Me.Controls("txtReplace" & i).text
-        caseFlags(i) = Me.Controls("chkCase" & i).Value
-        wordFlags(i) = Me.Controls("chkWhole" & i).Value
+        findTexts(i) = frmReplaceTool.Controls("txtFind" & i).text
+        replaceTexts(i) = frmReplaceTool.Controls("txtReplace" & i).text
+        caseFlags(i) = frmReplaceTool.Controls("chkCase" & i).Value
+        wordFlags(i) = frmReplaceTool.Controls("chkWhole" & i).Value
     Next i
 
     ProcessIndexedDocuments findTexts, replaceTexts, caseFlags, wordFlags, _
-        Me.chkExportPDF.Value, Me.cmbPDFType.text, Me.txtAltPDFPath.text, _
-        Me.txtPrefix.text, Me.txtSuffix.text, Me.chkKeepOriginal.Value, _
-        Me.cmbLanguage.text
+        frmReplaceTool.chkExportPDF.Value, frmReplaceTool.cmbPDFType.text, _
+        frmReplaceTool.txtAltPDFPath.text, frmReplaceTool.txtPrefix.text, _
+        frmReplaceTool.txtSuffix.text, frmReplaceTool.chkKeepOriginal.Value, _
+        frmReplaceTool.cmbLanguage.text
 End Sub
 
 

--- a/src/forms/frmReplaceTool.txt
+++ b/src/forms/frmReplaceTool.txt
@@ -14,25 +14,6 @@ Private Sub btnStart_Click()
     StartProcessing
 End Sub
 
-Private Sub StartProcessing()
-    Dim findTexts(1 To 5) As String
-    Dim replaceTexts(1 To 5) As String
-    Dim caseFlags(1 To 5) As Boolean
-    Dim wordFlags(1 To 5) As Boolean
-    Dim i As Long
-
-    For i = 1 To 5
-        findTexts(i) = Me.Controls("txtFind" & i).Text
-        replaceTexts(i) = Me.Controls("txtReplace" & i).Text
-        caseFlags(i) = Me.Controls("chkCase" & i).Value
-        wordFlags(i) = Me.Controls("chkWhole" & i).Value
-    Next i
-
-    ProcessIndexedDocuments findTexts, replaceTexts, caseFlags, wordFlags, _
-        Me.chkExportPDF.Value, Me.cmbPDFType.Text, Me.txtAltPDFPath.Text, _
-        Me.txtPrefix.Text, Me.txtSuffix.Text, Me.chkKeepOriginal.Value, _
-        Me.cmbLanguage.Text
-End Sub
 
 Private Sub btnCancel_Click()
     cancelRequested = True


### PR DESCRIPTION
## Summary
- reference frmReplaceTool explicitly inside `StartProcessing`
- drop obsolete StartProcessing procedure from text form

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68629d273ecc83268fe5e1c6798c7d68